### PR TITLE
Improve the behavior on high-dimensional problems

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -4,6 +4,14 @@ dummyvalue(::Type{T}) where T = typemax(T)
 isdummy(val::T) where T = isequal(val, dummyvalue(T))
 
 """
+    qnthresh(N)
+
+Return the minimum number of points needed to specify the quasi-Newton quadratic model
+in `N` dimensions.
+"""
+qnthresh(N) = ((N+1)*(N+2))÷2
+
+"""
    xvert, fvert, qcoef = qfit(xm=>fm, x0=>f0, xp=>fp)
 
 Given three points `xm < x0 < xp ` and three corresponding

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -327,3 +327,19 @@ end
     root, x0 = analyze(canyon, splits, lower, upper)
     @test length(leaves(root)) < 300
 end
+
+@testset "High dimensional" begin
+    B = randn(41, 40); B = B'*B
+    D, V = eig(B)
+    i = 1
+    while D[i] < 1e-4*D[end]
+        D[i] = 1e-4*D[end]
+    end
+    B = V*Diagonal(sqrt.(D)); B = B'*B
+    h(x) = (x'*B*x)/2
+    splits = [[-3,-2,-1] for i = 1:size(B,1)]
+    upper = fill(Inf, size(B,1))
+    lower = -upper
+    root, x0 = analyze(h, splits, lower, upper; maxevals=10000, fvalue=1e-3)
+    @test value(minimum(root)) <= 1e-3
+end


### PR DESCRIPTION
This solves a couple of problems the algorithm had with high-dimensional problems:
- it was consistently failing to gather enough independent points to solve for the full Hessian. This implements an adaptive threshold such that if it tries and fails, it doubles the minimum number required before trying again. This prevents it from wasting a lot of time.
- it terminates immediately if the `fvalue` criterion is satisfied. In high dimensions, one can often have met that criterion but have many more queued items, each of which might be time-consuming due to the use of quasi-Newton. By terminating immediately we avoid a long, unnecessary delay.
