### PR TITLE
Fix monotonicity bug: abort when split is too close to box boundry fo…

### DIFF
--- a/src/quadratic_model.jl
+++ b/src/quadratic_model.jl
@@ -213,7 +213,8 @@ function complete_quadratic_model!(Q::QmIGE, c, box::Box{T,N}, f::Function, x0, 
                 # Check that the box is big enough to split along this dimension
                 if !isroot(p)
                     bb = boxbounds(p)
-                    if !(bb[2] - bb[1] > epswidth(bb))
+                    bbeps = epswidth(bb)
+                    if !(bb[2] - bb[1] > bbeps) || !(bb[2] - xtmp[splitdim] > bbeps) || !(xtmp[splitdim] - bb[1] > bbeps)
                         return Q  # fail (FIXME?)
                     end
                 end


### PR DESCRIPTION
…r machine precision

This may fix both #8 and #13.  It definitely fixes the `ERROR: LoadError: AssertionError: xsplit[1] < xsplit[2] < xsplit[3]` reported in #8.  My fix may be a bit heavy-handed.  There was already a FIXME for a similar issue, indicating that @timholy  may have planned to handle this somewhere else upstream.  Let me know what you think.  cc @Animadversio and @ChantalJuntao.